### PR TITLE
Add hook parameter to register any additional info

### DIFF
--- a/pylibstats/visitor.py
+++ b/pylibstats/visitor.py
@@ -20,6 +20,8 @@ class Visitor(ast.NodeVisitor):
 
             The `.hook()` attribute can be set to a new hook at any time,
             typically just before a call to ``.visit()``.
+
+            To ensure BC of your hooks, make sure to define **kwargs in the signature.
     """
     def __init__(self, hook=None):
         super().__init__()

--- a/pylibstats/visitor.py
+++ b/pylibstats/visitor.py
@@ -3,7 +3,22 @@ from collections import defaultdict
 
 
 class Visitor(ast.NodeVisitor):
-    def __init__(self):
+    """AST Visitor that records imports, calls and attribute accesses.
+
+    Stores ``import_count``, ``call_count`` and ``access_count`` attribute
+    The main entry point is the ``visit(node: ast.AST)`` method.
+
+    Args:
+        hook (callable, optional): Optional hook that will be called on every hit i.e.
+            everytime an import, call or attribute access is encountered. Use this to record
+            any additional information you might need. The expected signature is
+            ``callable(node, name, kind)`` where:
+
+            - node is the ast.AST node being visited
+            - name is the name of the API being called/imported/accessed
+            - kind is one of "import", "call" or "access"
+    """
+    def __init__(self, hook=None):
         super().__init__()
         self.remapped = {}
         self.called = defaultdict(list)
@@ -13,6 +28,10 @@ class Visitor(ast.NodeVisitor):
         self.call_count = defaultdict(int)
         self.access_count = defaultdict(int)
 
+        def _noop(*args, **kwargs):
+            pass
+        self.hook = hook or _noop
+
     def visit_Import(self, node: ast.AST):
         for n in node.names:
             if n.asname:
@@ -20,6 +39,7 @@ class Visitor(ast.NodeVisitor):
             else:
                 self.remapped[n.name] = n.name
             self.import_count[n.name] += 1
+            self.hook(node=node, name=n.name, kind="import")
 
     def visit_ImportFrom(self, node: ast.AST):
         module = node.module
@@ -33,6 +53,7 @@ class Visitor(ast.NodeVisitor):
                 self.remapped[n.name] = name
 
             self.import_count[name] += 1
+            self.hook(node=node, name=name, kind="import")
 
     def visit_Call(self, node: ast.AST):
         self.generic_visit(node)
@@ -54,6 +75,7 @@ class Visitor(ast.NodeVisitor):
                     name = name + "." + v
                     self.called[name] += args
                     self.call_count[name] += 1
+                    self.hook(node=node, name=name, kind="call")
                     return
 
         func = node.func
@@ -61,6 +83,7 @@ class Visitor(ast.NodeVisitor):
             name = self.attrs[func]
             self.called[name] += args
             self.call_count[name] += 1
+            self.hook(node=node, name=name, kind="call")
         # all other cases are not supported for now
 
     def visit_Assign(self, node: ast.AST):
@@ -78,8 +101,10 @@ class Visitor(ast.NodeVisitor):
             nid, sts = _nested_attribute_and_name(node)
             if nid in self.remapped:
                 nid = self.remapped[nid]
-            self.attrs[node] = ".".join([nid] + sts)
-            self.access_count[self.attrs[node]] += 1
+            name = ".".join([nid] + sts)
+            self.attrs[node] = name
+            self.access_count[name] += 1
+            self.hook(node=node, name=name, kind="access")
             return
         return super().visit(node)
 

--- a/tests/test_visitor.py
+++ b/tests/test_visitor.py
@@ -60,3 +60,24 @@ def test_attr_shows():
     v.visit(co)
     assert "mylib.a" in v.attrs.values()
     assert "mylib.pkg.b" in v.attrs.values()
+
+
+def test_hook():
+    code = """
+import torch
+torch.rand(3)
+print(123)
+"""
+    log = []
+    def hook(node, name, kind):
+        log.append((name, kind))
+
+    Visitor(hook=hook).visit(ast.parse(code))
+
+    assert log == [
+        ('torch', 'import'),
+        ('torch.rand', 'access'),
+        ('torch.rand', 'call'),
+        ('print', 'access'),
+        ('print', 'call')
+    ]

--- a/tests/test_visitor.py
+++ b/tests/test_visitor.py
@@ -69,8 +69,8 @@ torch.rand(3)
 print(123)
 """
     log = []
-    def hook(node, name, kind):
-        log.append((name, kind))
+    def hook(node, api_name, kind):
+        log.append((api_name, kind))
 
     Visitor(hook=hook).visit(ast.parse(code))
 


### PR DESCRIPTION
This PR adds a `hook` callable parameter to let users register any additional information about imports/calls/accesses on top of the already registered ``import_count``, ``call_count`` and ``access_count`` attributes.



### Tests

```
(pt) ➜  python-lib-stats git:(alfjenalfjenaljenf) ✗ pytest tests -v 
================================================= test session starts =================================================
platform linux -- Python 3.9.16, pytest-7.4.4, pluggy-1.4.0 -- /home/nicolashug/.miniconda3/envs/pt/bin/python
cachedir: .pytest_cache
hypothesis profile 'default' -> database=DirectoryBasedExampleDatabase(PosixPath('/home/nicolashug/dev/python-lib-stats/.hypothesis/examples'))
rootdir: /home/nicolashug/dev/python-lib-stats
plugins: typeguard-2.13.3, cov-3.0.0, mock-3.7.0, anyio-3.5.0, hypothesis-6.88.1
collected 16 items                                                                                                    

tests/test_visitor.py::test_import_mapping[basic_import] PASSED                                                 [  6%]
tests/test_visitor.py::test_import_mapping[import_rename] PASSED                                                [ 12%]
tests/test_visitor.py::test_import_mapping[fromimport] PASSED                                                   [ 18%]
tests/test_visitor.py::test_import_mapping[fromimport3] PASSED                                                  [ 25%]
tests/test_visitor.py::test_import_mapping[fromimport_rename] PASSED                                            [ 31%]
tests/test_visitor.py::test_import_assign_call PASSED                                                           [ 37%]
tests/test_visitor.py::test_called[import mylib; mylib.func()-mylib.func] PASSED                                [ 43%]
tests/test_visitor.py::test_called[from mylib.pkg import func; func()-mylib.pkg.func] PASSED                    [ 50%]
tests/test_visitor.py::test_called[import mylib.pkg as T; T.func()-mylib.pkg.func] PASSED                       [ 56%]
tests/test_visitor.py::test_called[import mylib.pkg as T; T.subpkg.func()-mylib.pkg.subpkg.func] PASSED         [ 62%]
tests/test_visitor.py::test_getattr_in_call[getattr(mylib, 'func')()-mylib.func] PASSED                         [ 68%]
tests/test_visitor.py::test_getattr_in_call[getattr(mylib.pkg, 'func')()-mylib.pkg.func] PASSED                 [ 75%]
tests/test_visitor.py::test_getattr_in_call[getattr(mylib, variable)()-mylib.{?}] PASSED                        [ 81%]
tests/test_visitor.py::test_getattr_in_call[getattr(mylib, a.b.c)()-mylib.{?}] PASSED                           [ 87%]
tests/test_visitor.py::test_attr_shows PASSED                                                                   [ 93%]
tests/test_visitor.py::test_hook PASSED                                                                         [100%]
```